### PR TITLE
Release 0.2.0 -- add placement strategy and zone rebalancing

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -54,9 +54,15 @@ resource "aws_ecs_service" "service" {
   deployment_maximum_percent         = var.deployment_maximum_percent
   deployment_minimum_healthy_percent = var.deployment_minimum_healthy_percent
 
-  ordered_placement_strategy {
-    type  = "spread"
-    field = "instanceId"
+  availability_zone_rebalancing = var.availability_zone_rebalancing
+
+  dynamic "ordered_placement_strategy" {
+    for_each = var.ordered_placement_strategy
+
+    content {
+      field = try(ordered_placement_strategy.value.field, null)
+      type  = ordered_placement_strategy.value.type
+    }
   }
 
   load_balancer {

--- a/test/main.tf
+++ b/test/main.tf
@@ -6,9 +6,9 @@ module "minimal" {
   service_name       = ""
   service_env        = ""
   container_def_json = ""
-  desired_count      = ""
+  desired_count      = "1"
   lb_container_name  = ""
-  lb_container_port  = ""
+  lb_container_port  = "80"
   tg_arn             = ""
   ecsServiceRole_arn = ""
 }
@@ -16,20 +16,32 @@ module "minimal" {
 module "full" {
   source = "../"
 
-  cluster_id                         = ""
-  service_name                       = ""
-  service_env                        = ""
-  container_def_json                 = ""
-  desired_count                      = ""
-  lb_container_name                  = ""
-  lb_container_port                  = ""
-  tg_arn                             = ""
-  ecsServiceRole_arn                 = ""
+  cluster_id         = ""
+  service_name       = ""
+  service_env        = ""
+  container_def_json = ""
+  desired_count      = "1"
+  lb_container_name  = ""
+  lb_container_port  = "80"
+  tg_arn             = ""
+  ecsServiceRole_arn = ""
+
+  availability_zone_rebalancing      = true
   volumes                            = []
   task_role_arn                      = ""
-  network_mode                       = ""
-  deployment_maximum_percent         = ""
-  deployment_minimum_healthy_percent = ""
+  network_mode                       = "bridge"
+  deployment_maximum_percent         = "200"
+  deployment_minimum_healthy_percent = "50"
+  ordered_placement_strategy = [
+    {
+      type  = "spread"
+      field = "attribute:ecs.availability-zone"
+    },
+    {
+      type  = "spread"
+      field = "instanceId"
+    }
+  ]
 }
 
 output "task_def_arn" {

--- a/variables.tf
+++ b/variables.tf
@@ -42,10 +42,16 @@ variable "ecsServiceRole_arn" {
  * Optional Variables
  */
 
+variable "availability_zone_rebalancing" {
+  description = "When true, ECS automatically redistributes tasks within a service across Availability Zones"
+  type        = bool
+  default     = false
+}
+
 variable "volumes" {
-  default     = []
   description = "A list of volume definitions in JSON format that containers in your task may use"
   type        = list(any)
+  default     = []
 }
 
 variable "task_role_arn" {
@@ -66,4 +72,13 @@ variable "deployment_maximum_percent" {
 variable "deployment_minimum_healthy_percent" {
   type    = string
   default = 50
+}
+
+variable "ordered_placement_strategy" {
+  description = ""
+  type        = list(any)
+  default = [{
+    type  = "spread"
+    field = "instanceId"
+  }]
 }

--- a/versions.tf
+++ b/versions.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0.0, < 6.0.0"
+      version = ">= 5.0.0, < 6.0.0"
     }
   }
 }


### PR DESCRIPTION
### Added
- Added `availability_zone_rebalancing` input
- Added `ordered_placement_strategy` input

### Changed
- **BREAKING CHANGE** Upgrade minimum AWS Provider version to 5.0.0 to support `availability_zone_rebalancing`