### PR TITLE
Release 0.2.1 -- fix incorrect input type on availability_zone_rebalancing

### DIFF
--- a/test/main.tf
+++ b/test/main.tf
@@ -26,7 +26,7 @@ module "full" {
   tg_arn             = ""
   ecsServiceRole_arn = ""
 
-  availability_zone_rebalancing      = true
+  availability_zone_rebalancing      = "ENABLED"
   volumes                            = []
   task_role_arn                      = ""
   network_mode                       = "bridge"

--- a/variables.tf
+++ b/variables.tf
@@ -43,9 +43,12 @@ variable "ecsServiceRole_arn" {
  */
 
 variable "availability_zone_rebalancing" {
-  description = "When true, ECS automatically redistributes tasks within a service across Availability Zones"
-  type        = bool
-  default     = false
+  description = <<EOF
+    "When enabled, ECS automatically redistributes tasks within a service across Availability Zones. Must be
+    "either \"ENABLED\" or \"DISABLED\"."
+  EOF
+  type        = string
+  default     = "DISABLED"
 }
 
 variable "volumes" {

--- a/versions.tf
+++ b/versions.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0.0, < 6.0.0"
+      version = ">= 5.77.0, < 6.0.0"
     }
   }
 }


### PR DESCRIPTION
### Fixed
- Fixed aws provider version requirement. Version 5.77.0 is required for `availability_zone_rebalancing`.
- Fixed incorrect input type on `availability_zone_rebalancing`.