### PR TITLE
Release 0.3.0 -- make the load balancer optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,21 +8,4 @@ This module is published in [Terraform Registry](https://registry.terraform.io/m
 
 # Usage Example
 
-```hcl
-module "ecsservice" {
-  source  = "silinternational/ecs-service/aws"
-  version = ">= 0.2.0"
-
-  cluster_id         = module.ecscluster.ecs_cluster_id
-  service_name       = var.app_name
-  service_env        = var.app_env
-  container_def_json = file("task-definition.json")
-  desired_count      = 2
-  tg_arn             = data.terraform_remote_state.cluster.alb_default_tg_arn
-  lb_container_name  = "app"
-  lb_container_port  = 80
-  ecsServiceRole_arn = data.terraform_remote_state.core.ecsServiceRole_arn
-}
-```
-
 An [example](https://github.com/silinternational/terraform-aws-ecs-service/tree/main/example) usage of this module is included in the source repository.

--- a/example/main.tf
+++ b/example/main.tf
@@ -8,17 +8,19 @@ module "this" {
 
 module "ecsservice" {
   source  = "silinternational/ecs-service/aws"
-  version = ">= 0.1.0"
+  version = ">= 0.3.0"
 
   cluster_id         = module.ecscluster.ecs_cluster_id
   service_name       = var.app_name
   service_env        = var.app_env
   container_def_json = file("task-definition.json")
   desired_count      = 2
-  tg_arn             = data.terraform_remote_state.cluster.alb_default_tg_arn
-  lb_container_name  = "app"
-  lb_container_port  = 80
   ecsServiceRole_arn = data.terraform_remote_state.core.ecsServiceRole_arn
+  load_balancer = [{
+    target_group_arn = data.terraform_remote_state.cluster.alb_default_tg_arn
+    container_name   = "app"
+    container_port   = 80
+  }]
 
   volumes = [
     {

--- a/main.tf
+++ b/main.tf
@@ -66,10 +66,14 @@ resource "aws_ecs_service" "service" {
     }
   }
 
-  load_balancer {
-    target_group_arn = var.tg_arn
-    container_name   = var.lb_container_name
-    container_port   = var.lb_container_port
+  dynamic "load_balancer" {
+    for_each = var.load_balancer
+
+    content {
+      container_name   = load_balancer.value.container_name
+      container_port   = load_balancer.value.container_port
+      target_group_arn = load_balancer.value.target_group_arn
+    }
   }
 
   # Track the latest ACTIVE revision

--- a/outputs.tf
+++ b/outputs.tf
@@ -2,36 +2,44 @@
  * Task definition outputs
  */
 output "task_def_arn" {
-  value = aws_ecs_task_definition.td.arn
+  description = "ARN of the task definition"
+  value       = aws_ecs_task_definition.td.arn
 }
 
 output "task_def_family" {
-  value = aws_ecs_task_definition.td.family
+  description = "Family of the task definition"
+  value       = aws_ecs_task_definition.td.family
 }
 
 output "task_def_revision" {
-  value = aws_ecs_task_definition.td.revision
+  description = "Revision number of the task definition"
+  value       = aws_ecs_task_definition.td.revision
 }
 
 /*
  * Service outputs
  */
 output "service_id" {
-  value = aws_ecs_service.service.id
+  description = "ARN of the ECS service"
+  value       = aws_ecs_service.service.id
 }
 
 output "service_name" {
-  value = aws_ecs_service.service.name
+  description = "Name of the ECS service"
+  value       = aws_ecs_service.service.name
 }
 
 output "service_cluster" {
-  value = aws_ecs_service.service.cluster
+  description = "ARN of the ECS cluster"
+  value       = aws_ecs_service.service.cluster
 }
 
 output "service_role" {
-  value = aws_ecs_service.service.iam_role
+  description = "ARN of the IAM role that allows Amazon ECS to make calls to your load balancer on your behalf"
+  value       = aws_ecs_service.service.iam_role
 }
 
 output "service_desired_count" {
-  value = aws_ecs_service.service.desired_count
+  description = "The number of instances of the task definition to place and keep running"
+  value       = aws_ecs_service.service.desired_count
 }

--- a/test/main.tf
+++ b/test/main.tf
@@ -7,9 +7,6 @@ module "minimal" {
   service_env        = ""
   container_def_json = ""
   desired_count      = "1"
-  lb_container_name  = ""
-  lb_container_port  = "80"
-  tg_arn             = ""
   ecsServiceRole_arn = ""
 }
 
@@ -21,17 +18,20 @@ module "full" {
   service_env        = ""
   container_def_json = ""
   desired_count      = "1"
-  lb_container_name  = ""
-  lb_container_port  = "80"
-  tg_arn             = ""
+
+  load_balancer = [{
+    target_group_arn = ""
+    container_name   = ""
+    container_port   = 80
+  }]
   ecsServiceRole_arn = ""
 
   availability_zone_rebalancing      = "ENABLED"
   volumes                            = []
   task_role_arn                      = ""
   network_mode                       = "bridge"
-  deployment_maximum_percent         = "200"
-  deployment_minimum_healthy_percent = "50"
+  deployment_maximum_percent         = 200
+  deployment_minimum_healthy_percent = 50
   ordered_placement_strategy = [
     {
       type  = "spread"

--- a/variables.tf
+++ b/variables.tf
@@ -2,50 +2,73 @@
  * Required Variables
  */
 
-variable "cluster_id" {
-  type = string
-}
-
 variable "service_name" {
-  type = string
-}
-
-variable "service_env" {
-  type = string
+  description = "Name of the service, up to 255 letters (uppercase and lowercase), numbers, underscores, and hyphens."
+  type        = string
 }
 
 variable "container_def_json" {
-  type = string
+  description = "A list of valid container definitions provided as a single valid JSON document."
+  type        = string
 }
 
 variable "desired_count" {
-  type = string
+  description = "The number of instances of the task definition to place and keep running."
+  type        = number
 }
 
-variable "lb_container_name" {
-  type = string
-}
-
-variable "lb_container_port" {
-  type = string
-}
-
-variable "tg_arn" {
-  type = string
-}
-
-variable "ecsServiceRole_arn" {
-  type = string
-}
 
 /*
  * Optional Variables
  */
 
+variable "cluster_id" {
+  description = "ARN of the ECS cluster in which to place this service. If not specified, the default cluster is used."
+  type        = string
+  default     = null
+}
+
+variable "service_env" {
+  description = "Name of environment, used in naming task definition. Example: \"prod\"."
+  type        = string
+  default     = "prod"
+}
+
+variable "load_balancer" {
+  description = <<-EOF
+    Configuration block for load balancers.
+    Attributes:
+      target_group_arn - ARN of the Load Balancer target group to associate with the service.
+      container_name   - Container name to associate with the load balancer (as it appears in container definition).
+      container_port   - Port on the container to associate with the load balancer.
+    Example:
+      [{
+        target_group_arn = aws_alb_target_group.this.arn
+        container_name   = "app"
+        container_port   = 80
+      }]
+    EOF
+  type = list(object({
+    target_group_arn = string
+    container_name   = string
+    container_port   = number
+  }))
+  default = []
+}
+
+variable "ecsServiceRole_arn" {
+  description = <<-EOF
+    ARN of the IAM role that allows Amazon ECS to make calls to your load balancer on your behalf. Required if using a
+    load balancer.
+    EOF
+  type        = string
+  default     = null
+}
+
 variable "availability_zone_rebalancing" {
-  description = <<EOF
-    "When enabled, ECS automatically redistributes tasks within a service across Availability Zones. Must be
-    "either \"ENABLED\" or \"DISABLED\"."
+  description = <<-EOF
+    When enabled, ECS automatically redistributes tasks within a service across Availability Zones. Must be
+    either "ENABLED" or "DISABLED".
   EOF
   type        = string
   default     = "DISABLED"
@@ -58,28 +81,44 @@ variable "volumes" {
 }
 
 variable "task_role_arn" {
-  type    = string
-  default = ""
+  description = "ARN of IAM role that allows your Amazon ECS container task to make calls to other AWS services."
+  type        = string
+  default     = null
 }
 
 variable "network_mode" {
-  type    = string
-  default = "bridge"
+  description = <<-EOF
+    Docker networking mode to use for the containers in the task. Valid values are "none", "bridge", "awsvpc",
+    and "host".
+    EOF
+  type        = string
+  default     = "bridge"
 }
 
 variable "deployment_maximum_percent" {
-  type    = string
-  default = 200
+  description = <<-EOF
+    Upper limit (as a percentage of the service's desiredCount) of the number of running tasks that can be running in a
+    service during a deployment.
+    EOF
+  type        = number
+  default     = 200
 }
 
 variable "deployment_minimum_healthy_percent" {
-  type    = string
-  default = 50
+  description = <<-EOF
+    Lower limit (as a percentage of the service's desiredCount) of the number of running tasks that must remain running
+    and healthy in a service during a deployment.
+    EOF
+  type        = number
+  default     = 50
 }
 
 variable "ordered_placement_strategy" {
-  description = ""
-  type        = list(any)
+  description = "Service level strategy rules that are taken into consideration during task placement."
+  type = list(object({
+    type  = string
+    field = string
+  }))
   default = [{
     type  = "spread"
     field = "instanceId"
@@ -87,7 +126,10 @@ variable "ordered_placement_strategy" {
 }
 
 variable "execution_role_arn" {
-  description = "The IAM role that allows ECS to make AWS API calls on your behalf, such as to pull container images from ECR when using Fargate or to reference secrets from SSM Parameter Store."
+  description = <<-EOF
+    The IAM role that allows ECS to make AWS API calls on your behalf, such as to pull container images from ECR when
+    using Fargate or to reference secrets from SSM Parameter Store.
+    EOF
   type        = string
-  default     = ""
+  default     = null
 }


### PR DESCRIPTION
### Changed
- **BREAKING CHANGE**: Replaced variables `target_group_arn`, `container_name`, and `container_port` with a single optional variable `load_balancer`.
- Changed `desired_count`, `deployment_maximum_percent`, and `deployment_minimum_healthy_percent` from string to number. This could catch an invalid value earlier using "terraform validate" rather than waiting for the first plan.

### Added
- Added variable and output descriptions.
- Added default values for `cluster_id`, `service_env`, and `ecsServiceRole_arn`, making them optional.
- Changed `ecsServiceRole_arn`, `task_role_arn`, and `execution_role_arn` default from "" to null. This should have no impact, but is equivalent to specifying no value to the underlying resource.