### PR TITLE
Add task-level memory to ECS task definition for cgroup v2 compatibility

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -15,6 +15,7 @@ resource "aws_ecs_task_definition" "td" {
   task_role_arn         = var.task_role_arn
   execution_role_arn    = var.execution_role_arn
   network_mode          = var.network_mode
+  memory                = var.memory
 
   dynamic "volume" {
     for_each = var.volumes

--- a/main.tf
+++ b/main.tf
@@ -16,6 +16,7 @@ resource "aws_ecs_task_definition" "td" {
   execution_role_arn    = var.execution_role_arn
   network_mode          = var.network_mode
   memory                = var.memory
+  cpu                   = var.cpu
 
   dynamic "volume" {
     for_each = var.volumes

--- a/variables.tf
+++ b/variables.tf
@@ -114,7 +114,13 @@ variable "deployment_minimum_healthy_percent" {
 }
 
 variable "memory" {
-  description = "Task-level memory limit in MB. Required for cgroup v2 (AL2023) to properly scope memory per task. Set to the sum of all container hard memory limits in the task."
+  description = "Task-level memory limit in MB. Required for cgroup v2 (AL2023) to properly scope memory per task."
+  type        = number
+  default     = null
+}
+
+variable "cpu" {
+  description = "Task-level CPU reservation in CPU units (1 vCPU = 1024 units). Optional for EC2."
   type        = number
   default     = null
 }

--- a/variables.tf
+++ b/variables.tf
@@ -113,6 +113,12 @@ variable "deployment_minimum_healthy_percent" {
   default     = 50
 }
 
+variable "memory" {
+  description = "Task-level memory limit in MB. Required for cgroup v2 (AL2023) to properly scope memory per task. Set to the sum of all container hard memory limits in the task."
+  type        = number
+  default     = null
+}
+
 variable "ordered_placement_strategy" {
   description = "Service level strategy rules that are taken into consideration during task placement."
   type = list(object({


### PR DESCRIPTION
### Issue: 
Based on Matt's findings yesterday, AL2023 uses cgroup v2, which enforces memory boundaries more strictly than AL2 (cgroup v1). Without a task-level memory limit on aws_ecs_task_definition, ECS tasks have no parent cgroup with a memory bound. Under cgroup v2 this triggers the global OOM killer, causing unpredictable process kills across the host rather than scoping kills to the offending container.

### Change
Adds an optional memory variable (default null) to aws_ecs_task_definition. When set, this creates a task-level cgroup that properly bounds all containers in the task — the root fix for OOM kills on AL2023.

This is backward compatible: existing callers that don't pass memory get null, which leaves the task definition unchanged (same behaviour as before).